### PR TITLE
Hide next and previous buttons

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,12 @@
+root = true
+
+[*]
+indent_style = space
+indent_size = 2
+end_of_line = lf
+charset = utf-8
+trim_trailing_whitespace = true
+insert_final_newline = true
+
+[*.js]
+quote_type = single

--- a/README.md
+++ b/README.md
@@ -5,14 +5,16 @@
 I developed a simple script designed to enhance the Udemy viewing experience. When you install this, it can see **"Clean window"** button after/below video in left side.
 
 Key features of the script include:
-- Closing the sidebar
+- Closing/opening the sidebar
 - Toggling the video player control bar (hide/show)
 - Toggling the title bar and shadow (hide/show)
+- Toggling the next and previous buttons (hide/show)
 - Adjusting the video to fit the window size (not full screen)
 - Automatically scrolling to the video position
 
 > [!TIP]
-> This button is **toggle** button, so can hide or show video player control bar and title bar.
+> This button is **toggle** button, so can hide or show video player control bar, title bar and
+> next/previous buttons.
 > Keyboard arrow keys can be used to forward and backwards the video and also volume up and down.
 > Mouse can be used to Play and Push the video.
 
@@ -38,7 +40,7 @@ Key features of the script include:
 ------------
 
 > [!IMPORTANT]
-> Send me your suggestions. 
+> Send me your suggestions.
 
 ------------
 

--- a/Udemy-Clean-Window.js
+++ b/Udemy-Clean-Window.js
@@ -1,7 +1,7 @@
 // ==UserScript==
 // @name         Udemy Clean Window
 // @namespace    http://tampermonkey.net/
-// @version      0.1
+// @version      0.2
 // @description  Adds a toggle button to hide certain elements on Udemy course pages and adjusts max-height of specific element
 // @author       iNdra
 // @match        https://www.udemy.com/course/*
@@ -23,8 +23,9 @@
 
     if (targetElement) {
       // Create the toggle button
+      const buttonCleanText = 'Clean Window';
       const toggleButton = document.createElement('button');
-      toggleButton.innerText = 'Clean Window';
+      toggleButton.innerText = buttonCleanText;
 
       // Style the button
       toggleButton.style.backgroundColor = '#3498db';
@@ -53,44 +54,59 @@
           console.log(window.scrollY);
         }
 
+        let visibility = 'hidden';
+        const videoTitleElement = document.querySelector(
+          '.video-viewer--title-overlay--YZQuH',
+        );
+        // If the video title is hidden, restore elements visibility and open course content sidebar
+        const shouldRestoreVisibility =
+          videoTitleElement?.style.visibility === 'hidden';
+
         // Select the button with the data-purpose attribute
-        const specifiedButton = document.querySelector(
+        let openOrCloseSidebarButton = document.querySelector(
           '[data-purpose="sidebar-button-close"]',
         );
 
-        if (specifiedButton) {
-          specifiedButton.click(); // Programmatically click the button
+        if (shouldRestoreVisibility) {
+          toggleButton.textContent = buttonCleanText;
+          visibility = 'visible';
+          openOrCloseSidebarButton = document.querySelector(
+            '[data-purpose="open-course-content"]',
+          );
+        } else {
+          toggleButton.textContent = 'Restore Window';
         }
+
+        openOrCloseSidebarButton?.click(); // Programmatically click the button
 
         // Toggle the shaka-control-bar element
         const shakaElement = document.querySelector(
-          '.shaka-control-bar--control-bar-container--OfnMI',
+          '.shaka-control-bar-module--control-bar-container--xTkMB',
         );
         if (shakaElement) {
-          const currentVisibility = shakaElement.style.visibility;
-          shakaElement.style.visibility =
-            currentVisibility === 'hidden' ? 'visible' : 'hidden';
+          shakaElement.style.visibility = visibility;
         }
 
-        // Toggle the video-viewer-title-overlay element
-        const videoTitleElement = document.querySelector(
+        // Toggle the video-viewer--header-gradient element
+        const shadowbarElement = document.querySelector(
           '.video-viewer--header-gradient--x4Zw0',
         );
-        if (videoTitleElement) {
-          const currentVisibility = videoTitleElement.style.visibility;
-          videoTitleElement.style.visibility =
-            currentVisibility === 'hidden' ? 'visible' : 'hidden';
+        if (shadowbarElement) {
+          shadowbarElement.style.visibility = visibility;
         }
 
-        // Toggle the video-viewer-title-overlay element
-        const shadowbar = document.querySelector(
-          '.video-viewer--title-overlay--YZQuH',
-        );
-        if (shadowbar) {
-          const currentVisibility = shadowbar.style.visibility;
-          shadowbar.style.visibility =
-            currentVisibility === 'hidden' ? 'visible' : 'hidden';
+        // Toggle the video-viewer--title-overlay element
+        if (videoTitleElement) {
+          videoTitleElement.style.visibility = visibility;
         }
+
+        // Toggle the next-and-previous--container elements
+        const nextAndPreviousElements = document.querySelectorAll(
+          '.next-and-previous--container--kZxyo',
+        );
+        nextAndPreviousElements.forEach(function (element) {
+          element.style.visibility = visibility;
+        });
 
         const curriculumElements = document.querySelectorAll(
           '.curriculum-item-view--scaled-height-limiter--lEOjL.curriculum-item-view--no-sidebar--LGmz-',

--- a/Udemy-Clean-Window.js
+++ b/Udemy-Clean-Window.js
@@ -3,7 +3,7 @@
 // @namespace    http://tampermonkey.net/
 // @version      0.1
 // @description  Adds a toggle button to hide certain elements on Udemy course pages and adjusts max-height of specific element
-// @author       iNdra 
+// @author       iNdra
 // @match        https://www.udemy.com/course/*
 // @downloadURL  https://github.com/indramal/Udemy-Clean-Window/blob/main/Udemy-Clean-Window.js
 // @updateURL    https://github.com/indramal/Udemy-Clean-Window/blob/main/Udemy-Clean-Window.js
@@ -11,101 +11,114 @@
 // @grant        none
 // ==/UserScript==
 
-(function() {
-    'use strict';
+(function () {
+  'use strict';
 
-    // Function to add toggle button
-    function addToggleButton() {
-        // Select the target element before which the button should be added
-        const targetElement = document.querySelector('.app--row--E-WFM.app--dashboard--Z4Zxm');
+  // Function to add toggle button
+  function addToggleButton() {
+    // Select the target element before which the button should be added
+    const targetElement = document.querySelector(
+      '.app--row--E-WFM.app--dashboard--Z4Zxm',
+    );
 
-        if (targetElement) {
-            // Create the toggle button
-            const toggleButton = document.createElement('button');
-            toggleButton.innerText = 'Clean Window';
+    if (targetElement) {
+      // Create the toggle button
+      const toggleButton = document.createElement('button');
+      toggleButton.innerText = 'Clean Window';
 
-            // Style the button
-            toggleButton.style.backgroundColor = '#3498db';
-            toggleButton.style.color = '#fff';
-            toggleButton.style.border = 'none';
-            toggleButton.style.padding = '10px 20px';
-            toggleButton.style.borderRadius = '5px';
-            toggleButton.style.boxShadow = '0px 2px 5px rgba(0, 0, 0, 0.2)';
-            toggleButton.style.cursor = 'pointer';
-            toggleButton.style.marginBottom = '10px';
+      // Style the button
+      toggleButton.style.backgroundColor = '#3498db';
+      toggleButton.style.color = '#fff';
+      toggleButton.style.border = 'none';
+      toggleButton.style.padding = '10px 20px';
+      toggleButton.style.borderRadius = '5px';
+      toggleButton.style.boxShadow = '0px 2px 5px rgba(0, 0, 0, 0.2)';
+      toggleButton.style.cursor = 'pointer';
+      toggleButton.style.marginBottom = '10px';
 
-            // Add the toggle functionality
-            toggleButton.addEventListener('click', function() {
-              
-                // Get the height of the element with the specified classes
-                const headerElement = document.querySelector('.app--row--E-WFM.app--header--QuLOL');
-                const headerHeight = headerElement ? headerElement.offsetHeight : 0;
+      // Add the toggle functionality
+      toggleButton.addEventListener('click', function () {
+        // Get the height of the element with the specified classes
+        const headerElement = document.querySelector(
+          '.app--row--E-WFM.app--header--QuLOL',
+        );
+        const headerHeight = headerElement ? headerElement.offsetHeight : 0;
 
-              	if (window.scrollY !== headerHeight) {
-              		window.scrollTo({
-                    	top: 0,        // Scroll to the top of the page
-                    	left: 0,       // No horizontal scroll
-                    	behavior: 'smooth' // Smooth scrolling
-                	});
-                    console.log(window.scrollY);
-                }
-              
-                // Select the button with the data-purpose attribute
-                const specifiedButton = document.querySelector('[data-purpose="sidebar-button-close"]');
-              
-                if (specifiedButton) {
-                    specifiedButton.click(); // Programmatically click the button
-                }
-
-              
-                // Toggle the shaka-control-bar element
-                const shakaElement = document.querySelector('.shaka-control-bar--control-bar-container--OfnMI');
-                if (shakaElement) {
-                    const currentVisibility = shakaElement.style.visibility;
-                    shakaElement.style.visibility = currentVisibility === 'hidden' ? 'visible' : 'hidden';
-                }
-
-                // Toggle the video-viewer-title-overlay element
-                const videoTitleElement = document.querySelector('.video-viewer--header-gradient--x4Zw0');
-                if (videoTitleElement) {
-                    const currentVisibility = videoTitleElement.style.visibility;
-                    videoTitleElement.style.visibility = currentVisibility === 'hidden' ? 'visible' : 'hidden';
-                }
-              
-                // Toggle the video-viewer-title-overlay element
-                const shadowbar = document.querySelector('.video-viewer--title-overlay--YZQuH');
-                if (shadowbar) {
-                    const currentVisibility = shadowbar.style.visibility;
-                    shadowbar.style.visibility = currentVisibility === 'hidden' ? 'visible' : 'hidden';
-                }
-              
-                const curriculumElements = document.querySelectorAll('.curriculum-item-view--scaled-height-limiter--lEOjL.curriculum-item-view--no-sidebar--LGmz-');
-        		curriculumElements.forEach(function(element) {
-            		element.style.maxHeight = 'calc(100vh - 35px)';
-        		});
-              
-                if (window.scrollY !== headerHeight) {
-                	// Then, after scrolling to the top, scroll down by the header height
-                	setTimeout(function() {
-                    	window.scrollBy({
-                        	top: headerHeight,  // Scroll vertically by the header height
-                        	left: 0,  // No horizontal scroll
-                        	behavior: 'smooth' // Smooth scrolling
-                    	});
-                        console.log(window.scrollY);
-                	}, 500); // Delay to ensure the first scroll is completed
-                }  
-              
-              
-            });
-
-            // Insert the button before the target element
-            targetElement.parentNode.insertBefore(toggleButton, targetElement);
+        if (window.scrollY !== headerHeight) {
+          window.scrollTo({
+            top: 0, // Scroll to the top of the page
+            left: 0, // No horizontal scroll
+            behavior: 'smooth', // Smooth scrolling
+          });
+          console.log(window.scrollY);
         }
-    }
 
-    // Run the functions when the DOM is fully loaded
-    window.addEventListener('load', function() {
-        addToggleButton();
-    });
+        // Select the button with the data-purpose attribute
+        const specifiedButton = document.querySelector(
+          '[data-purpose="sidebar-button-close"]',
+        );
+
+        if (specifiedButton) {
+          specifiedButton.click(); // Programmatically click the button
+        }
+
+        // Toggle the shaka-control-bar element
+        const shakaElement = document.querySelector(
+          '.shaka-control-bar--control-bar-container--OfnMI',
+        );
+        if (shakaElement) {
+          const currentVisibility = shakaElement.style.visibility;
+          shakaElement.style.visibility =
+            currentVisibility === 'hidden' ? 'visible' : 'hidden';
+        }
+
+        // Toggle the video-viewer-title-overlay element
+        const videoTitleElement = document.querySelector(
+          '.video-viewer--header-gradient--x4Zw0',
+        );
+        if (videoTitleElement) {
+          const currentVisibility = videoTitleElement.style.visibility;
+          videoTitleElement.style.visibility =
+            currentVisibility === 'hidden' ? 'visible' : 'hidden';
+        }
+
+        // Toggle the video-viewer-title-overlay element
+        const shadowbar = document.querySelector(
+          '.video-viewer--title-overlay--YZQuH',
+        );
+        if (shadowbar) {
+          const currentVisibility = shadowbar.style.visibility;
+          shadowbar.style.visibility =
+            currentVisibility === 'hidden' ? 'visible' : 'hidden';
+        }
+
+        const curriculumElements = document.querySelectorAll(
+          '.curriculum-item-view--scaled-height-limiter--lEOjL.curriculum-item-view--no-sidebar--LGmz-',
+        );
+        curriculumElements.forEach(function (element) {
+          element.style.maxHeight = 'calc(100vh - 35px)';
+        });
+
+        if (window.scrollY !== headerHeight) {
+          // Then, after scrolling to the top, scroll down by the header height
+          setTimeout(function () {
+            window.scrollBy({
+              top: headerHeight, // Scroll vertically by the header height
+              left: 0, // No horizontal scroll
+              behavior: 'smooth', // Smooth scrolling
+            });
+            console.log(window.scrollY);
+          }, 500); // Delay to ensure the first scroll is completed
+        }
+      });
+
+      // Insert the button before the target element
+      targetElement.parentNode.insertBefore(toggleButton, targetElement);
+    }
+  }
+
+  // Run the functions when the DOM is fully loaded
+  window.addEventListener('load', function () {
+    addToggleButton();
+  });
 })();


### PR DESCRIPTION
## Changes

- Added an `.editorconfig` to standardize files format, formatted the JS script as it had mixed tabs/spaces.
- Next and previous buttons on the video player are now hidden/shown.
- The button now toggles its text between `Restore Window` and `Clean Window`.
- Course content sidebar now also opens when restoring the window.
- Fixed video player control bar CSS class.

## Pending Work

- Update the `README.md` images to reflect new behavior.
- Refactor the code to be more readable.

I'm happy to do this if you want me @indramal, just let me know.

---

Thanks @indramal for this script. Udemy's video player was annoying me as it does not hide those elements when on fullscreen.